### PR TITLE
Add Submission Agreement page

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -728,3 +728,12 @@ article.magazines ol.submissions li.collapsed.submission
   left: -3000em
   *
     height: 0
+
+a.submission-agreement-links
+  display: inline-block
+  font-size: 16px
+  margin-bottom: 24px
+  padding-right: 10px
+
+#padding-left
+  padding-left: 10px

--- a/app/assets/stylesheets/wysihtml5_submission.css.sass
+++ b/app/assets/stylesheets/wysihtml5_submission.css.sass
@@ -27,6 +27,9 @@ a.btn
   margin-left: 5px
   border-left: $border
 
+.max-width
+  max-width: none !important
+
 //IDs
 #wysihtml5-toolbar
   [data-wysihtml5-command=bold]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -6,12 +6,6 @@ class SubmissionsController < InheritedResources::Base
   end
   before_filter :ensure_current_url, :only => :show
 
-  # before_filter :submission_agreement, :only => :new
-
-  # def submission_agreement
-  #   redirect_to root_url
-  # end
-
   def index
     @magazines = current_person.magazines
     @magazine = params[:m].present? ? Magazine.find(params[:m]) : Magazine.current.presence || Magazine.first
@@ -38,6 +32,11 @@ class SubmissionsController < InheritedResources::Base
   end
 
   def new
+
+    unless params[:submission_agreement]
+      redirect_to submission_agreement_url and return
+    end
+
     session[:return_to] = request.referer unless begin URI(request.referer).path == "/submissions" rescue false end
     if person_signed_in?
       @submission = Submission.new :author_id => current_person.id, :state => :draft

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -72,7 +72,8 @@ class SubmissionsController < InheritedResources::Base
             redirect_to submissions_url and return if current_person.orchestrates?(:current) && params["preview"]
             if @submission.published?
               flash[:notice] = "#@submission has been published and is on <a href='/magazines/#{@submission.magazine.to_param}/#{@submission.page.to_param}'>page #{@submission.page} of #{@submission.magazine}</a>.".html_safe
-              redirect_to new_submission_url and return
+              redirect_to new_submission_url(:submission_agreement => true) and return
+              # redirect_to new_submission_url and return
             end
             redirect_to person_url(current_person)
           else
@@ -106,7 +107,8 @@ class SubmissionsController < InheritedResources::Base
         format.html {
           if @submission.published?
             flash[:notice] = "#@submission has been published and is on <a href='/magazines/#{@submission.magazine.to_param}/#{@submission.page.to_param}'>page #{@submission.page} of #{@submission.magazine}</a>.".html_safe
-            redirect_to new_submission_url and return
+            # redirect_to new_submission_url and return
+            redirect_to new_submission_url(:submission_agreement => true) and return
           else
             redirect_to session[:return_to] || request.referer
           end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -6,6 +6,12 @@ class SubmissionsController < InheritedResources::Base
   end
   before_filter :ensure_current_url, :only => :show
 
+  # before_filter :submission_agreement, :only => :new
+
+  # def submission_agreement
+  #   redirect_to root_url
+  # end
+
   def index
     @magazines = current_person.magazines
     @magazine = params[:m].present? ? Magazine.find(params[:m]) : Magazine.current.presence || Magazine.first
@@ -17,6 +23,10 @@ class SubmissionsController < InheritedResources::Base
     @unscheduled_submissions = Submission.where(:state => Submission.state(:submitted))
   end
 
+  def submission_agreement
+
+  end
+  
   def show
     @submission = Submission.find(params[:id])
     @average = @submission.magazine.try(:average_score).presence

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -3,7 +3,7 @@
 
   %label{ :for => 'submission_title'} Title
   %h1
-    = f.text_field :title, :autofocus => true, class: 'no-focus-outline'
+    = f.text_field :title, :autofocus => true, class: 'no-focus-outline max-width'
   %label{ :for => 'wysihtml5-textarea'} Body
   #submission-body-container
     #wysihtml5-toolbar{style: "display: none;"}
@@ -130,48 +130,3 @@
         parserRules:  wysihtml5ParserRules
       });
     });
-
-- content_for :sidebar do
-  %section#answers
-    %header
-      %h2 FAQ
-    %dl
-      %dt
-        %span.arrow &raquo;
-        How will you review my submission?
-      %dd
-        :markdown
-          Your name will be removed when this is reviewed;
-          only the editor
-          #{"([#{Person.current_communicators.collect(&:name).to_sentence}][1])" if Person.current_communicators.present?}
-          will know you wrote this. And only the coeditor
-          #{"([#{Person.current_scorers.collect(&:name).to_sentence}][2])" if Person.current_scorers.present?}
-          will know how people score it.
-          Everyone else has the privilege of judging it objectively.
-
-            [1]: #{begin person_path(Person.current_communicators.first) rescue "/people" end}
-            [2]: #{begin person_path(Person.current_scorers.first) rescue "/people" end}
-
-          "Everyone else" means anyone who wanders into the weekly meeting
-          at which your submission is reviewed (you can go, too! It's a good
-          way to get very honest feedback). For more info on meetings, visit the [about page](#{root_path}).
-      %dt
-        %span.arrow &raquo;
-        What can I submit?
-      %dd
-        :markdown
-          * Art: We accept photographs & scanned art.
-          * Poetry: There are no hard and fast rules for the poetry we accept. Insider’s tip – we strongly dislike centered poetry. Of course, that could change if it’s centered for a brilliant reason.
-          * Prose: We ask that you keep your prose to 1,000 words at most, though we’ve published pieces that are wonderful & a bit over the limit.
-      %dt
-        %span.arrow &raquo;
-        What gets in?
-      %dd
-        :markdown
-          We pride ourselves on considering each submission at length, discussing lines we love, potential deeper meanings, or where the piece falls just short of our expectations. We also like to hold a poem on its side to see if it makes a groovy shape. Each staff member gives each submission a number from 1 – 10, and at the end of the semester we average all the scores for all the pieces. The top 50 (give or take) make it in!
-      %dt
-        %span.arrow &raquo;
-        How do I know if I made it?
-      %dd
-        :markdown
-          If you have an account on this website, you'll automatically get an email telling you which of your submissions we've published. If you don't... We'll try to remember to email you! Either way, these emails will come around the end of the academic semester (December in the fall, May in the spring).

--- a/app/views/submissions/index.html.haml
+++ b/app/views/submissions/index.html.haml
@@ -4,7 +4,7 @@
   = render partial: 'magazines/sidebar'
 
 :markdown
-  #{link_to "Submit something", new_submission_path}  
+  #{link_to "Submit something", controller: "submissions", action: "submission_agreement"}  
   #{link_to "Schedule a new meeting", new_meeting_path}
 
 - for meeting in @meetings_to_come

--- a/app/views/submissions/index.html.haml
+++ b/app/views/submissions/index.html.haml
@@ -4,7 +4,7 @@
   = render partial: 'magazines/sidebar'
 
 :markdown
-  #{link_to "Submit something", controller: "submissions", action: "submission_agreement"}  
+  #{link_to "Submit something", new_submission_path}  
   #{link_to "Schedule a new meeting", new_meeting_path}
 
 - for meeting in @meetings_to_come

--- a/app/views/submissions/submission_agreement.html.haml
+++ b/app/views/submissions/submission_agreement.html.haml
@@ -1,5 +1,39 @@
-%div HELLOOOOOOO!!!!!!
 
-= link_to "Got It, Let's Write!", new_submission_path
+:markdown
+  ## Submission FAQs
 
-= link_to "Back", :back
+  ### How will you review my submission?
+  Your name will be removed when this is reviewed;
+  only the editor
+  #{"([#{Person.current_communicators.collect(&:name).to_sentence}][1])" if Person.current_communicators.present?}
+  will know you wrote this. And only the coeditor
+  #{"([#{Person.current_scorers.collect(&:name).to_sentence}][2])" if Person.current_scorers.present?}
+  will know how people score it.
+  Everyone else has the privilege of judging it objectively.
+
+    [1]: #{begin person_path(Person.current_communicators.first) rescue "/people" end}
+    [2]: #{begin person_path(Person.current_scorers.first) rescue "/people" end}
+
+  "Everyone else" means anyone who wanders into the weekly meeting
+  at which your submission is reviewed (you can go, too! It's a good
+  way to get very honest feedback). For more info on meetings, visit the [about page](#{root_path}).
+
+  ### What can I submit?
+
+  * Art: We accept photographs & scanned art.
+  * Poetry: There are no hard and fast rules for the poetry we accept. Insider’s tip – we strongly dislike centered poetry. Of course, that could change if it’s centered for a brilliant reason.
+  * Prose: We ask that you keep your prose to 1,000 words at most, though we’ve published pieces that are wonderful & a bit over the limit.
+
+  ### What gets in?
+
+  We pride ourselves on considering each submission at length, discussing lines we love, potential deeper meanings, or where the piece falls just short of our expectations. We also like to hold a poem on its side to see if it makes a groovy shape. Each staff member gives each submission a number from 1 – 10, and at the end of the semester we average all the scores for all the pieces. The top 50 (give or take) make it in!
+
+  ### How do I know if I made it?
+
+  If you have an account on this website, you'll automatically get an email telling you which of your submissions we've published. If you don't... We'll try to remember to email you! Either way, these emails will come around the end of the academic semester (December in the fall, May in the spring).
+
+
+= link_to "Got It, Let's Write!", new_submission_path(:submission_agreement => true), class: 'submission-agreement-links'
+Or
+= link_to "Back", :back, class: 'submission-agreement-links', id: 'padding-left'
+

--- a/app/views/submissions/submission_agreement.html.haml
+++ b/app/views/submissions/submission_agreement.html.haml
@@ -1,0 +1,5 @@
+%div HELLOOOOOOO!!!!!!
+
+= link_to "Got It, Let's Write!", new_submission_path
+
+= link_to "Back", :back

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Pc::Application.routes.draw do
     end
   end
 
+  get 'submission_agreement', to: 'submissions#submission_agreement'
+
   resources :submissions, :path => 'submissions', :only => [:index, :create]
   resources :submissions, :path => '', :except => [:index, :create], :path_names => { :new => "/submit" }
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -43,12 +43,10 @@ end
 
 Given /^(?:|I )(?:am on|visit) (.+)$/ do |page_name|
   visit path_to(page_name)
-  # visit "/submit?submission_agreement=true"
 end
 
 When /^(?:|I )go to (.+)$/ do |page_name|
   visit path_to(page_name)
-  # visit new_submission_path(:submission_agreement => true)
 end
 
 When /^(?:|I )press "([^"]*)"$/ do |button|

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -43,10 +43,12 @@ end
 
 Given /^(?:|I )(?:am on|visit) (.+)$/ do |page_name|
   visit path_to(page_name)
+  # visit "/submit?submission_agreement=true"
 end
 
 When /^(?:|I )go to (.+)$/ do |page_name|
   visit path_to(page_name)
+  # visit new_submission_path(:submission_agreement => true)
 end
 
 When /^(?:|I )press "([^"]*)"$/ do |button|
@@ -185,7 +187,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should not be checked$/ do |label
 end
 
 Then /^(?:|I )should be on (.+)$/ do |page_name|
-  current_path = URI.parse(current_url).path
+  current_path = URI.parse(current_url).request_uri
   if current_path.respond_to? :should
     current_path.should == path_to(page_name)
   else

--- a/features/submission_lifecycle.feature
+++ b/features/submission_lifecycle.feature
@@ -5,14 +5,13 @@ Feature: A poet's work goes from draft to published/rejected
 
   Scenario: I write a poem and then submit it later with edits
     Given I sign in
-    And I am on the new submission page
+    And I am on the submit page
     When I fill in the following:
       | Title | Each raindrop   |
       | Body  | started as dust |
     And press "Preview"
     Then I should be on my profile page
     And I should see "Drafts"
-
     When I follow "Edit" under "Each raindrop"
     And I press "Submit!"
     Then I should be on my profile page

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -25,7 +25,8 @@ module NavigationHelpers
       "/people/#{person.to_param}"
 
     when /the submit page/i
-      "/submit"
+      # "/submit"
+      "/submit?submission_agreement=true"
 
     when /the magazine's cover page/i
       "/magazines/#{Magazine.first.to_param}/#{Page.where(position: 1).first.to_param}"

--- a/features/various_people_submit_their_work.feature
+++ b/features/various_people_submit_their_work.feature
@@ -6,7 +6,7 @@ Feature: people of various ranks submit something
   Scenario: The editor submits something
     Given I'm in a position for the current magazine with the "communicates" ability
     And no emails have been sent
-    And I am on the new submission page
+    And I am on the submit page
     When I fill in the following:
       | Title | Old King Scole |
       | Body  | Chewed Tobaccy |
@@ -42,7 +42,7 @@ Feature: people of various ranks submit something
   Scenario: Some other signed-in person submits something
     Given I sign in
     And no emails have been sent
-    And I am on the new submission page
+    And I am on the submit page
     When I fill in the following:
       | Title | Merry Wives |
       | Body  | of Pirates  |
@@ -63,7 +63,7 @@ Feature: people of various ranks submit something
     Given the following user exists:
       | name         | email             |
       | Roger Rabbit | roger@example.com |
-    And I am on the new submission page
+    And I am on the submit page
     When I fill in the following:
       | Your Name          | Pickles           |
       | Your Email Address | roger@example.com |
@@ -73,7 +73,7 @@ Feature: people of various ranks submit something
     Then "roger@example.com" should receive an email with subject "Someone \(hopefully you!\) submitted to Problem Child for you!"
 
   Scenario: A bot fills out the honypot fields
-    Given I am on the new submission page
+    Given I am on the submit page
     When I fill in the following:
       | Title                           | Jackson, a favorite       |
       | Body                            | of both Johnny and Sufjan |
@@ -85,7 +85,7 @@ Feature: people of various ranks submit something
     And there should be no new submission
 
   Scenario: An anonymous visitor submits something & thus signs up
-    Given I am on the new submission page
+    Given I am on the submit page
     When I fill in the following:
       | Title                           | Jackson, a favorite       |
       | Body                            | of both Johnny and Sufjan |
@@ -103,7 +103,7 @@ Feature: people of various ranks submit something
 
   Scenario: I submit under a psuedonym linked to my profile
     Given I sign in
-    And I am on the new submission page
+    And I am on the submit page
     When I fill in the following:
       | Title     | Merry Wives   |
       | Body      | of Pirates    |
@@ -117,7 +117,7 @@ Feature: people of various ranks submit something
 
   Scenario: I submit under a psuedonym that is not linked to my profile
     Given I sign in
-    And I am on the new submission page
+    And I am on the submit page
     When I fill in the following:
       | Title     | Merry Wives   |
       | Body      | of Pirates    |


### PR DESCRIPTION
I wasn't exactly sure the approach you wanted to take with the switching off in the controller based on params...

I mocked up an alternative. Basically, whenever the user clicks on one of the "make a submission" type links, instead of being directed to `new_submission_path`, they get directed to a different path/page I created, submission_agreement.html.haml.

The user clicks on the "I agree, let's write" button at which point they're directed to the submission form. If they don't agree to the terms, they just click "back" and return to the previous page. 

I did a quick search to see how many times the `new_submission_path` link appears, it's like 5 times. So, it wouldn't be a super pain to change those to direct to the submission_agreement page. 

Anyway, I think your way was a bit different. Let me know what you think. If you want to approach this a completely different way than what I began, just give me a hint or two and I'll jump back in :)
