### PR TITLE
Tips for editors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 
 group :development do
   gem 'daemons' # for running DJ
+  gem 'quiet_assets'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
       http_parser.rb (~> 0.5.3)
       multi_json (~> 1.0)
     polyglot (0.3.3)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -336,6 +338,7 @@ DEPENDENCIES
   paperclip
   pg (~> 0.11)
   poltergeist
+  quiet_assets
   rack-timeout
   rails (~> 3.2.0)
   rails_12factor

--- a/app/assets/javascripts/typsy.js.coffee
+++ b/app/assets/javascripts/typsy.js.coffee
@@ -1,0 +1,6 @@
+jQuery ->
+  toggles = $("[data-behavior=typsy-toggle]")
+  tips    = $("[data-behavior=typsy-container]")
+  toggles.click (e) ->
+    tips.fadeToggle()
+    e.preventDefault()

--- a/app/assets/javascripts/typsy.js.coffee
+++ b/app/assets/javascripts/typsy.js.coffee
@@ -1,6 +1,9 @@
 jQuery ->
-  toggles = $("[data-behavior=typsy-toggle]")
-  tips    = $("[data-behavior=typsy-container]")
-  toggles.click (e) ->
-    tips.fadeToggle()
+  toggles = "[data-behavior=typsy-toggle]"
+  tips    = "[data-behavior=typsy-container]"
+  user    = $(tips).data("user")
+  $(document).on "click", toggles, (e) ->
+    $(tips).fadeToggle()
     e.preventDefault()
+  $(document).on "click", "#{tips} input:checkbox", ->
+    $.post("/people/#{user}/toggle_default_tips")

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -761,7 +761,7 @@ article.magazines ol.submissions li.collapsed.submission
   .fa
     width: 13%
   .tip-text
-    width: 85%
+    width: 80%
   li:not(:last-child)
     margin-bottom: 1em
   .actions

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -21,6 +21,7 @@ a.mailto
   width: 16px
   display: inline-block
   text-indent: -3000em
+  vertical-align: middle
 
 .inline-block
   display: inline-block
@@ -734,7 +735,7 @@ article.magazines ol.submissions li.collapsed.submission
     height: 0
 
 .tips
-  line-height: 1.9em // somehow fixes the position??
+  line-height: 1.1em // somehow fixes the position??
   position: absolute
   right: 0
   z-index: 2

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -74,8 +74,8 @@ a.mailto
     +box-shadow($lgray 0 0 3px inset)
     width: 100%
     background-color: $blue
+    position: relative
     text-align: center
-    +opacity(0.9)
     +border-radius(20px 0)
     margin:
       left: 0
@@ -98,7 +98,6 @@ a.mailto
 
   & > article
     +span-columns($article)
-    position: relative
     &.full-width
       +span-columns($total-columns)
 
@@ -735,9 +734,9 @@ article.magazines ol.submissions li.collapsed.submission
     height: 0
 
 .tips
+  line-height: 1.9em // somehow fixes the position??
   position: absolute
   right: 0
-  top: 0
   z-index: 2
   a
     color: $base
@@ -749,7 +748,7 @@ article.magazines ol.submissions li.collapsed.submission
   padding: 1em 0 0
   position: absolute
   right: 0
-  top: 4px
+  text-align: left
   width: 25em
   z-index: 1
   ol
@@ -759,9 +758,9 @@ article.magazines ol.submissions li.collapsed.submission
     +inline-block
     vertical-align: middle
   .fa
-    width: 13%
+    width: 11%
   .tip-text
-    width: 80%
+    width: 83%
   li:not(:last-child)
     margin-bottom: 1em
   .actions

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -98,6 +98,7 @@ a.mailto
 
   & > article
     +span-columns($article)
+    position: relative
     &.full-width
       +span-columns($total-columns)
 
@@ -732,3 +733,42 @@ article.magazines ol.submissions li.collapsed.submission
   left: -3000em
   *
     height: 0
+
+.tips
+  position: absolute
+  right: 0
+  top: 0
+  z-index: 2
+  a
+    color: $base
+.tip-container
+  border: 1px solid $lgray
+  border-radius: 0.5em
+  box-shadow: 1px 3px 15px rgba(0,0,0,0.3)
+  background-color: white
+  padding: 1em 0 0
+  position: absolute
+  right: 0
+  top: 4px
+  width: 25em
+  z-index: 1
+  ol
+    list-style-type: none
+    margin: 0
+  .fa, .tip-text, .actions > *
+    +inline-block
+    vertical-align: middle
+  .fa
+    width: 13%
+  .tip-text
+    width: 85%
+  li:not(:last-child)
+    margin-bottom: 1em
+  .actions
+    padding: 1em 1em 0.5em
+    label, button
+      font-weight: normal
+      display: inline
+    button
+      padding: 0 0.6em
+      margin: 0

--- a/app/assets/stylesheets/print.css.sass
+++ b/app/assets/stylesheets/print.css.sass
@@ -52,6 +52,8 @@ h2, h3, header
 
 section#packlet
   margin-top: 24pt
+  .right a // Print or PDF button
+    display: none
 
 li.packlet, li.submission
   margin-bottom: 24pt
@@ -68,7 +70,7 @@ li.packlet, li.submission
       display: none
     p
       margin-bottom: 0
-    nav.actions
+    nav.actions, form
       display: none
 
 span.drag-handle, section#attendance, input, article > header > div, .actions

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
 
   def set_tips
     @tips = PageTips.new("#{params[:controller]}##{params[:action]}", current_person, @show_conditional_tips).tips
+    @show_tips_at_page_load = css_display_for_tips
   end
 
   protected
@@ -55,6 +56,14 @@ class ApplicationController < ActionController::Base
 
     def not_found
       raise ActionController::RoutingError.new('Not Found')
+    end
+
+    def css_display_for_tips
+      if @tips && current_person.show_tips_at_page_load
+        "block"
+      else
+        "none"
+      end
     end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_filter :reset_return_to_maybe
   before_filter :find_publication
+  before_filter :set_tips
 
   def reset_return_to_maybe
     if session[:return_to]
@@ -17,6 +18,10 @@ class ApplicationController < ActionController::Base
 
   def find_publication
     @publication = current_publication
+  end
+
+  def set_tips
+    @tips = PageTips.new("#{params[:controller]}##{params[:action]}", current_person, @show_conditional_tips).tips
   end
 
   protected

--- a/app/controllers/magazines_controller.rb
+++ b/app/controllers/magazines_controller.rb
@@ -19,6 +19,8 @@ class MagazinesController < InheritedResources::Base
                  else
                    @publication.magazines.where('published_on IS NOT NULL')
                  end
+    @show_conditional_tips = @magazines.any?(&:timeframe_freshly_over?)
+    set_tips
   end
 
   def new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,8 @@ class PagesController < ApplicationController
   respond_to :html
   respond_to :js, only: [:update, :add_submission]
 
+  include ApplicationHelper
+
   before_filter except: :show do |c|
     c.must_orchestrate @publication
   end
@@ -15,6 +17,8 @@ class PagesController < ApplicationController
       flash[:notice] = "That hasn't been published yet, check back soon!"
       redirect_to root_url(subdomain: @publication.subdomain) and return
     end
+    @show_conditional_tips = orchestrates?(@magazine) && !@magazine.notification_sent
+    set_tips
   end
 
   def create

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -4,6 +4,10 @@ class PeopleController < InheritedResources::Base
   end
   before_filter :ensure_current_url, :only => :show
 
+  respond_to :js, only: :toggle_default_tips
+
+  skip_before_filter :find_publication, only: :toggle_default_tips
+
   def autocomplete
     terms = params[:term].split(' ')
     @people = terms.map do |term|
@@ -50,6 +54,12 @@ class PeopleController < InheritedResources::Base
     Communications.delay.contact_person(@to, @from, @subject, @message)
     flash[:notice] = "Your message has been sent!"
     redirect_to person_url(@to, subdomain: @publication.subdomain)
+  end
+
+  def toggle_default_tips
+    person = Person.find(params[:id])
+    person.update_attribute :show_tips_at_page_load, !person.show_tips_at_page_load
+    head :ok
   end
 
 protected

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -13,10 +13,6 @@ class PublicationsController < ApplicationController
     @homepage = Homepage.new(@publication)
     @show_conditional_tips = !!@homepage.hook_present?
     set_tips
-
-    respond_to do |format|
-      format.html
-    end
   end
 
   def new

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,5 +1,3 @@
-require 'homepage'
-
 class PublicationsController < ApplicationController
   before_filter :except => [:show, :new, :create] do |c|
     c.must_orchestrate @publication
@@ -13,6 +11,8 @@ class PublicationsController < ApplicationController
   def show
     @publication = current_publication
     @homepage = Homepage.new(@publication)
+    @show_conditional_tips = !!@homepage.hook_present?
+    set_tips
 
     respond_to do |format|
       format.html

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -6,6 +6,8 @@ class SubmissionsController < InheritedResources::Base
   end
   before_filter :ensure_current_url, :only => :show
 
+  include ApplicationHelper
+
   def index
     @magazines = current_person.magazines
     @magazine = @publication.magazines.where(id: params[:m]).first.presence || @publication.current_magazine
@@ -20,11 +22,6 @@ class SubmissionsController < InheritedResources::Base
   def show
     @submission = Submission.find(params[:id])
     @average = @submission.magazine.try(:average_score).presence
-
-    respond_to do |format|
-      format.html # show.html.erb
-      format.xml  { render :xml => @submission }
-    end
   end
 
   def new
@@ -36,10 +33,8 @@ class SubmissionsController < InheritedResources::Base
       @submission.extend HoneyPot
     end
 
-    respond_to do |format|
-      format.html # new.html.erb
-      format.xml  { render :xml => @submission }
-    end
+    @show_conditional_tips = communicates? @publication
+    set_tips
   end
 
   def edit

--- a/app/models/magazine.rb
+++ b/app/models/magazine.rb
@@ -185,6 +185,10 @@ class Magazine < ActiveRecord::Base
 
   memoize :average_score, :to_s
 
+  def timeframe_freshly_over?
+    published_on.nil? && accepts_submissions_until < Time.zone.now
+  end
+
 protected
 
   def accepts_from_after_latest_or_perhaps_today

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -98,14 +98,12 @@ class Person < ActiveRecord::Base
   # ABILITIES
   #
 
-  def communicates? resource, *flags
-    resource = primary_publication if resource.nil?
+  def communicates? resource = primary_publication, *flags
     positions = positions_for resource, *flags
     positions.joins(:abilities).where(:abilities => { :key => "communicates" }).present?
   end
 
-  def orchestrates? resource, *flags
-    resource = primary_publication if resource.nil?
+  def orchestrates? resource = primary_publication, *flags
     positions = positions_for(resource, *flags)
     positions.joins(:abilities).where(:abilities => { :key => "orchestrates" }).present?
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -68,14 +68,13 @@ class Person < ActiveRecord::Base
     name
   end
 
-  # function to set the password without knowing the current password used in our confirmation controller.
-  def attempt_set_password(params)
-    p = {}
-    p[:password] = params[:password]
-    p[:password_confirmation] = params[:password_confirmation]
-    update_attributes(p)
+  def attempt_to_set_password(params)
+    parms = {}
+    parms[:password] = params[:password]
+    parms[:password_confirmation] = params[:password_confirmation]
+    update_attributes(parms)
   end
-  # function to return whether a password has been set
+
   def has_no_password?
     self.encrypted_password.blank?
   end

--- a/app/services/homepage.rb
+++ b/app/services/homepage.rb
@@ -9,6 +9,10 @@ class Homepage
     yield(@hook) if @hook
   end
 
+  def hook_present?
+    !!@hook
+  end
+
   private
 
     def magazine_for(publication)

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -50,6 +50,12 @@ class PageTips
         "If you want to re-review a submission at multiple meetings, drag it from the old meeting to the new one." => "info",
         "See a list of all the submissions for some other issue by clicking that issue in the sidebar." => "info",
       }
+    when "submissions#new"
+      { "Most people will be see \"Submit\" in the nav bar instead of \"Submissions\", so it will be easy for them to get here. You see \"Submissions\" because you have the \"orchestrates\" ability (see a magazine's staff list page to learn about abilities)." => "info",
+        "Anonymous, not-signed-in visitors can submit and will be signed up in the process." => "info",
+        "You can backfill old issues by submitting here as usual, but select the older issue from the list at the bottom." => "info",
+        "As you can see at the bottom, you can submit for anyone. This is because you have the \"communicates\" ability for an issue. (Again, visit a staff list to learn about abilities.)" => "key",
+      }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips
     tips

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -11,10 +11,10 @@ class PageTips
     tips = case @page
     when "publications#show"
       { "This page features one of your published works, randomly selected on each page load." => "key",
-        "This is your home page. You can edit the content on it with the link at the bottom." => "info",
+        "This is your home page. You can edit the content on it with the pencil link at the bottom." => "info",
       }
     when "magazines#index"
-      { "It looks like an issue's submission period is over, so you can review its highest-scored submissions." => "key",
+      { "It looks like an issue's submission period is over! You can review it's highest scored submissions and then publish it so everyone in the world can come read it." => "key",
         "Click 'Staff List' for any issue to fine-tune who can view submissions' authors, scores, and meetings for that issue." => "info",
       }
     when "magazines#highest_scores"
@@ -55,6 +55,11 @@ class PageTips
         "Anonymous, not-signed-in visitors can submit and will be signed up in the process." => "info",
         "You can backfill old issues by submitting here as usual, but select the older issue from the list at the bottom." => "info",
         "As you can see at the bottom, you can submit for anyone. This is because you have the \"communicates\" ability for an issue. (Again, visit a staff list to learn about abilities.)" => "key",
+      }
+    when "people#show"
+      { "On your own page, you can keep track of everything you've submitted. You can see what's been scheduled for review, what's been scored & how it's been scored, works that made it & works that didn't." => "info",
+        "All other visitors to your page will see only your published works." => "info",
+        "We at Publishist think that the list of positions you accrue in the sidebar looks great on a resumé. ;-)" => "info",
       }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -1,0 +1,30 @@
+class PageTips
+  def initialize(page, person, include_conditional_tips)
+    @page = page
+    @person = person
+    @include_conditional_tips = include_conditional_tips
+  end
+
+  def tips
+    return nil unless @person && @person.orchestrates?
+
+    tips = case @page
+    when "publications#show"
+      { "This is your home page. You can edit the content on it with the link at the bottom." => "info",
+        "This page features one of your published works, randomly selected on each page load." => "key",
+      }
+    when "magazines#index"
+      { "Click 'Staff List' for any issue to fine-tune who can view submissions' authors, scores, and meetings for that issue." => "info",
+        "It looks like an issue's submission period is over, so you can review its highest-scored submissions." => "key"
+      }
+    end
+    tips = remove_conditional(tips) unless @include_conditional_tips
+    tips
+  end
+
+  private
+
+  def remove_conditional(tips)
+    tips and tips.reject { |key, value| value == "key" }
+  end
+end

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -26,6 +26,12 @@ class PageTips
         "You can click the right edge of a submission and drag to a new page (note: it will drop onto the page with the dotted outline, not necessarily the one you're moused over. :-/ )" => "info",
         "Click the big plus at the bottom left to add notes or special items to pages." => "info",
       }
+    when "magazines#staff_list"
+      { "This is your main command center. All of the permissions for the whole website are based on what's on these staff lists; controlled issue-by-issue." => "info",
+        "Mouse over the little circular letters next to the name of each position to see what abilities people in that position have." => "info",
+        "You can edit the abilities for a position by clicking the pencil icons. You can also rename positions that way." => "info",
+        "To keep everything from breaking, if someone has the \"orchestrates\" ability for an issue, they'll be able to edit the staff lists of adjacent issues." => "info"
+      }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips
     tips

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -37,6 +37,12 @@ class PageTips
         "You don't have to do that, but be aware that scores can only be entered from a meeting's page, so you'll have to at least pretend you have coordinated meetings." => "info",
         "Each meeting has a \"Question\". Answering a creative question makes roll call way more fun." => "info",
       }
+    when "meetings#show"
+      { "This is where you'll probably spend most of your time, if you have regular staff meetings." => "info",
+        "Attendees listed at the bottom can enter their own scores for the submissions at the top. (Bring laptops to the meeting & do it there!)" => "info",
+        "If attendees don't enter their own scores, then someone with the \"scores\" ability can for them (control permissions on the staff list page, accessed from the magazines list)." => "info",
+        "Each attendee can also edit their own answer to the attendance question by mousing over & clicking their current answer." => "info",
+      }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips
     tips

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -29,8 +29,13 @@ class PageTips
     when "magazines#staff_list"
       { "This is your main command center. All of the permissions for the whole website are based on what's on these staff lists; controlled issue-by-issue." => "info",
         "Mouse over the little circular letters next to the name of each position to see what abilities people in that position have." => "info",
-        "You can edit the abilities for a position by clicking the pencil icons. You can also rename positions that way." => "info",
+        "You don't have to name your positions this way. Each issue can have uniquely-named positions, and different permission structures. Click the pencil icons to see." => "info",
         "To keep everything from breaking, if someone has the \"orchestrates\" ability for an issue, they'll be able to edit the staff lists of adjacent issues." => "info"
+      }
+    when "meetings#index"
+      { "Publishist encourages you to have regularly-scheduled, real-life meetings of your staff where you read submissions aloud, discuss, and score them." => "info",
+        "You don't have to do that, but be aware that scores can only be entered from a meeting's page, so you'll have to at least pretend you have coordinated meetings." => "info",
+        "Each meeting has a \"Question\". Answering a creative question makes roll call way more fun." => "info",
       }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -10,12 +10,21 @@ class PageTips
 
     tips = case @page
     when "publications#show"
-      { "This is your home page. You can edit the content on it with the link at the bottom." => "info",
-        "This page features one of your published works, randomly selected on each page load." => "key",
+      { "This page features one of your published works, randomly selected on each page load." => "key",
+        "This is your home page. You can edit the content on it with the link at the bottom." => "info",
       }
     when "magazines#index"
-      { "Click 'Staff List' for any issue to fine-tune who can view submissions' authors, scores, and meetings for that issue." => "info",
-        "It looks like an issue's submission period is over, so you can review its highest-scored submissions." => "key"
+      { "It looks like an issue's submission period is over, so you can review its highest-scored submissions." => "key",
+        "Click 'Staff List' for any issue to fine-tune who can view submissions' authors, scores, and meetings for that issue." => "info",
+      }
+    when "magazines#highest_scores"
+      { "These are the highest-scored submissions for this issue. You can uncheck some, if you don't want them published." => "info",
+      }
+    when "pages#show"
+      { "This will not be publicly browsable until you click \"Let everyone who submitted know it's been published\"." => "key",
+        "Use the inline controls in the pagination to add & remove pages." => "info",
+        "You can click the right edge of a submission and drag to a new page (note: it will drop onto the page with the dotted outline, not necessarily the one you're moused over. :-/ )" => "info",
+        "Click the big plus at the bottom left to add notes or special items to pages." => "info",
       }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips

--- a/app/services/page_tips.rb
+++ b/app/services/page_tips.rb
@@ -29,7 +29,7 @@ class PageTips
     when "magazines#staff_list"
       { "This is your main command center. All of the permissions for the whole website are based on what's on these staff lists; controlled issue-by-issue." => "info",
         "Mouse over the little circular letters next to the name of each position to see what abilities people in that position have." => "info",
-        "You don't have to name your positions this way. Each issue can have uniquely-named positions, and different permission structures. Click the pencil icons to see." => "info",
+        "You don't have to name your positions this way. Each issue can have uniquely-named positions, and different permission structures. Use the pencil icons to change it up." => "info",
         "To keep everything from breaking, if someone has the \"orchestrates\" ability for an issue, they'll be able to edit the staff lists of adjacent issues." => "info"
       }
     when "meetings#index"
@@ -42,6 +42,13 @@ class PageTips
         "Attendees listed at the bottom can enter their own scores for the submissions at the top. (Bring laptops to the meeting & do it there!)" => "info",
         "If attendees don't enter their own scores, then someone with the \"scores\" ability can for them (control permissions on the staff list page, accessed from the magazines list)." => "info",
         "Each attendee can also edit their own answer to the attendance question by mousing over & clicking their current answer." => "info",
+      }
+    when "submissions#index"
+      { "Think of this as your Publishist inbox. When people submit, the submissions show up here." => "info",
+        "Schedule submissions for meetings by dragging and dropping them." => "info",
+        "You can reorder submissions within a meeting by clicking through to the meeting's page (the orange dates are the links you want)." => "info",
+        "If you want to re-review a submission at multiple meetings, drag it from the old meeting to the new one." => "info",
+        "See a list of all the submissions for some other issue by clicking that issue in the sidebar." => "info",
       }
     end
     tips = remove_conditional(tips) unless @include_conditional_tips

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -49,6 +49,7 @@
           - if content_for? :header
             %div
               = yield :header
+        = render "shared/typsy"
         = yield
       - if content_for? :sidebar
         %section.sidebar{ :id => "#{@article_id}-sidebar" }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,6 +37,7 @@
         %h1
           = link_to @publication.name, root_url
         %p= @publication.tagline
+        = render "shared/typsy"
       - if flash[:notice]
         #notice= flash[:notice]
       - if flash[:alert]
@@ -49,7 +50,6 @@
           - if content_for? :header
             %div
               = yield :header
-        = render "shared/typsy"
         = yield
       - if content_for? :sidebar
         %section.sidebar{ :id => "#{@article_id}-sidebar" }

--- a/app/views/magazines/_show.html.haml
+++ b/app/views/magazines/_show.html.haml
@@ -29,5 +29,5 @@
           confirm: "You're saying this magazine never actually happened. All of its meetings will be unassociated with any magazine. If this magazine has been published, all of the submissions submitted for it will be simply \"Scored\" again.",
           class: 'link destroy',
           title: "Destroy this magazine and everything associated with it."
-  - if orchestrates?(magazine) && (magazine.accepts_submissions_until < Time.now && magazine.published_on == nil)
+  - if orchestrates?(magazine) && magazine.timeframe_freshly_over?
     %div= link_to "View the highest-scored submissions", highest_scored_for_magazine_path(magazine)

--- a/app/views/meetings/_form.html.haml
+++ b/app/views/meetings/_form.html.haml
@@ -3,7 +3,7 @@
 
   = f.input :datetime, :label => "When", :as => :string, :input_html => { :value => (resource.datetime ? resource.datetime.strftime("%Y-%m-%d %I:%M %p") : nil) }
   = f.input :question
-  = f.association :magazine, :label_method => :present_name
+  = f.association :magazine, :label_method => :present_name, collection: @publication.magazines
   = f.button :submit
 
 = content_for :javascript do

--- a/app/views/pages/_pagination.html.haml
+++ b/app/views/pages/_pagination.html.haml
@@ -1,10 +1,10 @@
 %nav.pagination<
   %ol.pages<
-    - if orchestrates? @magazine
+    - if orchestrates? @publication
       = render partial: "pages/form", locals: { position: :beginning }
     - for page in @magazine.pages
-      - if orchestrates?(@magazine) || page.has_content?
-        - if page == @page && orchestrates?(@magazine)
+      - if orchestrates?(@publication) || page.has_content?
+        - if page == @page && orchestrates?(@publication)
           %li[page]<
             = page.title
             = link_to fa_icon("times"), [@magazine, page],
@@ -14,5 +14,5 @@
         - else
           %li[page]<
             = link_to_unless page == @page, page.title, magazine_page_path(@magazine, page)
-    - if orchestrates? @magazine
+    - if orchestrates? @publication
       = render partial: "pages/form", locals: { position: :end }

--- a/app/views/pages/show.html.haml
+++ b/app/views/pages/show.html.haml
@@ -18,7 +18,7 @@
   - if submissions = @page.submissions
     = render "submissions/index", submissions: submissions
     - collapse_resources = true unless submissions.empty?
-  - if orchestrates? @magazine
+  - if orchestrates? @publication
     = render "add_resources", collapse: collapse_resources
   = render "pagination"
   - if orchestrates? @magazine and not @magazine.notification_sent?

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -1,5 +1,5 @@
 - title @person.full_name
-- unless @person == current_person || @published.present?
+- if @person != current_person && @published.empty?
   = render :partial => 'about', :locals => { :person => @person }
 - else
   - content_for :sidebar do

--- a/app/views/shared/_each_tip.html.haml
+++ b/app/views/shared/_each_tip.html.haml
@@ -1,0 +1,4 @@
+- @tips.each do |text, icon|
+  %li
+    = fa_icon icon, class: "fa-fw"
+    %span.tip-text= text

--- a/app/views/shared/_typsy.html.haml
+++ b/app/views/shared/_typsy.html.haml
@@ -1,0 +1,13 @@
+- if @tips
+  .tips{ "data-behavior" => "typsy-toggle" }
+    = link_to fa_icon("question-circle"), "#toggle-tips"
+  .tip-container{ "data-behavior" => "typsy-container" }
+    %ol
+      = render "shared/each_tip"
+    .actions
+      %small
+        = check_box_tag "show_by_default", true, true
+        %label(for="show_by_default") Show these tips at page load
+      %span.right
+        %button{ "data-behavior" => "typsy-toggle" }
+          OK

--- a/app/views/shared/_typsy.html.haml
+++ b/app/views/shared/_typsy.html.haml
@@ -1,12 +1,12 @@
 - if @tips
   .tips{ "data-behavior" => "typsy-toggle" }
     = link_to fa_icon("question-circle"), "#toggle-tips"
-  .tip-container{ "data-behavior" => "typsy-container" }
+  .tip-container{ style: "display: #{@show_tips_at_page_load}", data: { behavior: "typsy-container", user: current_person.id } }
     %ol
       = render "shared/each_tip"
     .actions
       %small
-        = check_box_tag "show_by_default", true, true
+        = check_box_tag "show_by_default", true, current_person.show_tips_at_page_load
         %label(for="show_by_default") Show these tips at page load
       %span.right
         %button{ "data-behavior" => "typsy-toggle" }

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -64,7 +64,7 @@
         label:      "Author (you can submit for anyone)",
         input_html: { :value => "#{resource.author(true).name_and_email if @submission.author(true)}" },
         hint:       "You can even make an account for someone by entering their name & email"
-      = f.association :magazine, label_method: :to_s
+      = f.association :magazine, label_method: :to_s, collection: @publication.magazines
     - else
       = f.input :author_id, :as => :hidden
   - else

--- a/app/views/submissions/_show.html.haml
+++ b/app/views/submissions/_show.html.haml
@@ -1,7 +1,7 @@
 - collapsed   = collapsed.nil?   ? true : collapsed
 - show_author = show_author.nil? ? true : show_author
 %li[submission]{ :class => collapsed && "collapsed" }
-  - if orchestrates?(submission.magazine) && !(params[:controller] == "magazines" && params[:action] == "highest_scores")
+  - if orchestrates?(@publication) && !(params[:controller] == "magazines" && params[:action] == "highest_scores")
     %span.drag-handle-wrap
       %span.drag-handle.fa.fa-bars
   - if params[:controller] == "magazines" && params[:action] == "highest_scores"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,10 @@ Pc::Application.routes.draw do
     end
 
     resources :people, except: [:index, :new] do
-      member { post "contact" }
+      member do
+        post "contact"
+        post "toggle_default_tips", as: "toggle_default_tips_for"
+      end
       collection { get "autocomplete" }
     end
 

--- a/db/migrate/20131107021705_add_show_tips_at_page_load_to_people.rb
+++ b/db/migrate/20131107021705_add_show_tips_at_page_load_to_people.rb
@@ -1,0 +1,5 @@
+class AddShowTipsAtPageLoadToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :show_tips_at_page_load, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131003000738) do
+ActiveRecord::Schema.define(:version => 20131107021705) do
 
   create_table "abilities", :force => true do |t|
     t.string   "key"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(:version => 20131003000738) do
     t.string   "password_salt"
     t.string   "slug"
     t.integer  "primary_publication_id"
+    t.boolean  "show_tips_at_page_load", :default => true
   end
 
   add_index "people", ["confirmation_token"], :name => "index_people_on_confirmation_token", :unique => true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,7 +53,7 @@ disappears =   Ability.find_or_create_by_key_and_description 'disappears', "Subm
     :accepts_submissions_from  => Time.zone.now - 13.months,
     :accepts_submissions_until => Time.zone.now - 7.months,
   )
-  mag2 = Magazine.find_or_create_by_nickname_and_title_and_publication_id('almost published', "#{publication.name} vol. 2", publication.id)
+  mag2 = Magazine.find_or_create_by_nickname_and_title_and_publication_id('could be published', "#{publication.name} vol. 2", publication.id)
   mag2.update_attributes(
     :accepts_submissions_from  => Time.zone.now - 7.months + 1.day,
     :accepts_submissions_until => Time.zone.now - 1.month,
@@ -168,7 +168,6 @@ disappears =   Ability.find_or_create_by_key_and_description 'disappears', "Subm
   score.update_attributes(:amount => 5)
   score = Score.find_or_create_by_packlet_id_and_attendee_id(packlet.id, attendee3.id)
   score.update_attributes(:amount => 5, :entered_by_coeditor => true)
-  mag2.publish([hold])
 
   ###############
   ### ISSUE 3 ###

--- a/features/person_signs_up.feature
+++ b/features/person_signs_up.feature
@@ -13,6 +13,7 @@ Feature: a person signs up for the website
     Then I should be on the home page
     And there should be no new users
 
+  @wip
   Scenario: I sign up on the site
     Given I am on the sign up page
     When I fill in the following:

--- a/features/person_signs_up.feature
+++ b/features/person_signs_up.feature
@@ -13,7 +13,6 @@ Feature: a person signs up for the website
     Then I should be on the home page
     And there should be no new users
 
-  @wip
   Scenario: I sign up on the site
     Given I am on the sign up page
     When I fill in the following:

--- a/spec/models/magazine_spec.rb
+++ b/spec/models/magazine_spec.rb
@@ -551,4 +551,31 @@ describe Magazine do
     end
   end
 
+  describe "#timeframe_freshly_over?" do
+    let(:magazine) { stub_model(Magazine, published_on: nil) }
+
+    context "when published_on is nil" do
+      context "when #accepts_submissions_until is in the past" do
+        it "returns true" do
+          magazine.stub(:accepts_submissions_until).and_return(Time.zone.now - 1.minute)
+          expect(magazine.timeframe_freshly_over?).to be_true
+        end
+      end
+      context "when #accepts_submissions_until is in the future" do
+        it "returns false" do
+          magazine.stub(:accepts_submissions_until).and_return(Time.zone.now + 1.minute)
+          expect(magazine.timeframe_freshly_over?).to be_false
+        end
+      end
+    end
+
+    context "when published_on is present" do
+      it "returns false, even when #accepts_submissions_from is in the past" do
+        magazine.stub(:published_on).and_return(Time.zone.now)
+        magazine.stub(:accepts_submissions_until).and_return(Time.zone.now - 1.minute)
+        expect(magazine.timeframe_freshly_over?).to be_false
+      end
+    end
+  end
+
 end

--- a/spec/requests/magazines_spec.rb
+++ b/spec/requests/magazines_spec.rb
@@ -13,7 +13,7 @@ describe "Magazines" do
       end
     end
 
-    context "when not signed in" do
+    context "when signed in" do
       it "only shows magazines from the current publication" do
         sign_in
         visit magazines_url(subdomain: publications.first.subdomain)

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -1,16 +1,28 @@
 require 'spec_helper'
 
 describe "People" do
-  let!(:publications) { [Factory.create(:publication), Factory.create(:publication)] }
-  let!(:people) { [Factory.create(:person, primary_publication_id: publications.first.id),
-                   Factory.create(:person, primary_publication_id: publications.last.id)] }
 
   describe "GET /autocomplete" do
+    let!(:publications) { [Factory.create(:publication), Factory.create(:publication)] }
+    let!(:people) { [Factory.create(:person, primary_publication_id: publications.first.id),
+                     Factory.create(:person, primary_publication_id: publications.last.id)] }
+
     it "only includes users from the current publication" do
       get autocomplete_people_url(subdomain: publications.first.subdomain, term: "Julia") # the factory names everyone Julia
       expect(response.status).to eq(200)
       expect(response.body).to match(people.first.email)
       expect(response.body).not_to match(people.last.email)
+    end
+  end
+
+  describe "POST /:id/toggle_default_tips" do
+    let(:person) { Factory.create :person, show_tips_at_page_load: true }
+    it "toggles #show_tips_at_page_load for the person" do
+      post toggle_default_tips_for_person_path(person)
+      expect(person.reload.show_tips_at_page_load).to be_false
+
+      post toggle_default_tips_for_person_path(person)
+      expect(person.reload.show_tips_at_page_load).to be_true
     end
   end
 end

--- a/spec/requests/publications_spec.rb
+++ b/spec/requests/publications_spec.rb
@@ -24,6 +24,7 @@ describe "Publications" do
     let(:publication) { Publication.find_by_name(name) }
     before do
       post "http://whatever.publishist.dev/publications", "publication_name" => name, "editor_email" => email
+      Person.any_instance.stub(:orchestrates?).and_return(false)
     end
     it "creates a publication, an editor, sample data, and signs the editor in" do
       expect(Publication.count).to eq 1

--- a/spec/services/homepage_spec.rb
+++ b/spec/services/homepage_spec.rb
@@ -1,0 +1,25 @@
+require_relative "../../app/services/homepage"
+
+describe Homepage do
+  let(:publication) { double.as_null_object }
+  let(:homepage) { Homepage.new(publication) }
+
+  it "is instantiated with one arg, a publication object" do
+    expect(Homepage.new(publication)).to be_kind_of Homepage
+  end
+
+  describe "hook_present?" do
+    context "when a hook submission is successfully found" do
+      it "returns true" do
+        expect(homepage.hook_present?).to be_true
+      end
+    end
+
+    context "when no hook submission can be found" do
+      it "returns false" do
+        Homepage.any_instance.stub(:submission_for).and_return(nil)
+        expect(homepage.hook_present?).to be_false
+      end
+    end
+  end
+end

--- a/spec/services/page_tips_spec.rb
+++ b/spec/services/page_tips_spec.rb
@@ -1,0 +1,55 @@
+require_relative "../../app/services/page_tips"
+
+describe PageTips do
+  let(:page) { "publications#show" }
+  let(:person) { double("person", orchestrates?: false) }
+  let(:include_conditional_tips) { false }
+  let(:page_tips) { PageTips.new(page, person, include_conditional_tips) }
+
+  it "is instantiated with three args, the symbolized name of the page, a person, and whether to include conditional tips" do
+    expect(PageTips.new(:home, person, false)).to be_kind_of PageTips
+  end
+
+  describe "#tips" do
+    context "when the person is nil (not signed in)" do
+      let(:person) { nil }
+      it "returns nil" do
+        expect(page_tips.tips).to be_nil
+      end
+    end
+
+    context "when the person doesn't have the orchestrates ability" do
+      it "returns nil" do
+        expect(page_tips.tips).to be_nil
+      end
+    end
+    context "when the person has the orchestrates ability" do
+      let(:person) { double("person", orchestrates?: true) }
+
+      it "returns a hash" do
+        expect(page_tips.tips).to be_kind_of Hash
+      end
+
+      context "when show_conditional_tips == false" do
+        it "doesn't include tips with value of 'key'" do
+          expect(page_tips.tips.values).not_to include "key"
+        end
+      end
+
+      context "when show_conditional_tips == true" do
+        let(:include_conditional_tips) { true }
+        it "includes tips with value of 'key'" do
+          expect(page_tips.tips.values).to include "key"
+        end
+      end
+
+      context "when there are no tips for the provided page" do
+        let(:page) { "notapage" }
+        it "returns nil" do
+          expect(page_tips.tips).to be_nil
+        end
+      end
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ module RequestHelpers
     ApplicationController.any_instance.stub(:authenticate_person!).and_return(true)
     ApplicationController.any_instance.stub(:person_signed_in?).and_return(true)
     ApplicationController.any_instance.stub(:current_person).and_return(@person)
+    @person.stub(:orchestrates?).and_return(false)
     if as.to_sym == :editor
       ApplicationController.any_instance.stub(:must_orchestrate).and_return(true)
       ApplicationController.any_instance.stub(:must_view).and_return(true)


### PR DESCRIPTION
Add per-page tips that only editors will see. This is to help people get oriented after signing up or after becoming an editor.
